### PR TITLE
Fix the receiptTime

### DIFF
--- a/rqt_multiplot/include/rqt_multiplot/BagQuery.h
+++ b/rqt_multiplot/include/rqt_multiplot/BagQuery.h
@@ -47,6 +47,7 @@ namespace rqt_multiplot {
     void aboutToBeDestroyed();
   
   private:
+    ros::Time startTime_;
     variant_topic_tools::MessageDataType dataType_;
     variant_topic_tools::MessageSerializer serializer_;
     

--- a/rqt_multiplot/include/rqt_multiplot/MessageSubscriber.h
+++ b/rqt_multiplot/include/rqt_multiplot/MessageSubscriber.h
@@ -61,6 +61,7 @@ namespace rqt_multiplot {
   
   private:
     ros::NodeHandle nodeHandle_;
+    ros::Time startTime_;
     
     QString topic_;
     size_t queueSize_;

--- a/rqt_multiplot/src/rqt_multiplot/BagQuery.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/BagQuery.cpp
@@ -40,7 +40,8 @@ namespace rqt_multiplot {
 /*****************************************************************************/
 
 BagQuery::BagQuery(QObject* parent) :
-  QObject(parent) {
+  QObject(parent),
+  startTime_(ros::Time::now()) {
 }
 
 BagQuery::~BagQuery() {
@@ -95,7 +96,10 @@ void BagQuery::callback(const rosbag::MessageInstance& instance) {
   
   serializer_.deserialize(inputStream, variant);
   
-  message.setReceiptTime(instance.getTime());
+  ros::Time tmp;
+  tmp.sec = (instance.getTime() - startTime_).sec;
+  tmp.nsec = (instance.getTime() - startTime_).nsec;
+  message.setReceiptTime(tmp);
   message.setVariant(variant);
   
   MessageEvent* messageEvent = new MessageEvent(QString::fromStdString(

--- a/rqt_multiplot/src/rqt_multiplot/MessageSubscriber.cpp
+++ b/rqt_multiplot/src/rqt_multiplot/MessageSubscriber.cpp
@@ -34,7 +34,8 @@ MessageSubscriber::MessageSubscriber(QObject* parent, const ros::NodeHandle&
     nodeHandle) :
   QObject(parent),
   nodeHandle_(nodeHandle),
-  queueSize_(100) {
+  queueSize_(100)
+  startTime_(ros::Time::now()) {
 }
 
 MessageSubscriber::~MessageSubscriber() {
@@ -127,7 +128,10 @@ void MessageSubscriber::callback(const variant_topic_tools::MessageVariant&
     variant, const ros::Time& receiptTime) {
   Message message;
   
-  message.setReceiptTime(receiptTime);
+  ros::Time tmp;
+  tmp.sec = (receiptTime - startTime_).sec;
+  tmp.nsec = (receiptTime - startTime_).nsec;
+  message.setReceiptTime(tmp);
   message.setVariant(variant);
 
   MessageEvent* messageEvent = new MessageEvent(topic_, message);


### PR DESCRIPTION
Now the receiptTime starts with the program and not from the UNIX time.
The time axis is thus more meaningful.