### PR TITLE
CurveDataSequence::processMessage: Catch variant_topic_tools exception

### DIFF
--- a/src/rqt_multiplot/CurveDataSequencer.cpp
+++ b/src/rqt_multiplot/CurveDataSequencer.cpp
@@ -179,10 +179,16 @@ void CurveDataSequencer::processMessage(const Message& message) {
     point.setX(message.getReceiptTime().toSec());
   
   if (yAxisConfig->getFieldType() == CurveAxisConfig::MessageData) {
-    variant_topic_tools::BuiltinVariant variant = message.getVariant().
-      getMember(yAxisConfig->getField().toStdString());
-      
-    point.setY(variant.getNumericValue());
+    try {
+      variant_topic_tools::BuiltinVariant variant = message.getVariant().
+        getMember(yAxisConfig->getField().toStdString());
+
+      point.setY(variant.getNumericValue());
+    } catch (const variant_topic_tools::NoSuchMemberException& e) {
+      ROS_WARN_STREAM_ONCE("Exception in processMessage while retrieving"
+        " member '" << yAxisConfig->getField().toStdString() << "': " <<
+        e.what());
+    }
   }
   else
     point.setY(message.getReceiptTime().toSec());


### PR DESCRIPTION
This commit catches an exception of type 'variant_topic_tools::NoSuchMemberException' which previously caused a program crash. These exceptions can get thrown for instance if a message does not contain the selected field. Instead, a single warning will be printed to the console.

**Background:**
I am using a config file for multiple setups - in some cases certain messages are not published. Thus, while other messages could be plotted one might not be. This currently terminates by throwing with:
```
terminate called after throwing an instance of 'variant_topic_tools::NoSuchMemberException'
  what():  Member with index [0] does not exist
```

Would it be okay to catch and either warn or catch and ignore? Would you prefer an alternate approach?